### PR TITLE
fix verify_request_components variable assignment

### DIFF
--- a/lib/signet/oauth_1/server.rb
+++ b/lib/signet/oauth_1/server.rb
@@ -147,15 +147,20 @@ module Signet
       # @return [Hash] normalized request components
       def verify_request_components(options={})
         if options[:request]
-          if options[:request].kind_of?(Faraday::Request) || options[:request].kind_of?(Array)
-            request = options[:request]
-          elsif options[:adapter]
-            request = options[:adapter].adapt_request(options[:request])
+          request = options[:request]
+
+          if options[:adapter]
+            request = options[:adapter].adapt_request(request)
           end
-          method = request.method
-          uri = request.path
-          headers = request.headers
-          body = request.body
+
+          if request.kind_of?(Array)
+            method, uri, headers, body = request
+          else
+            method = request.method
+            uri = request.path
+            headers = request.headers
+            body = request.body
+          end
         else
           method = options[:method] || :get
           uri = options[:uri]


### PR DESCRIPTION
If `request` is an array, `verify_request_components` raises a `NoMethodError` when trying to access `request.method`.

To reduce the number of conditionals, this commit also makes the assumption that if `options[:adapter]` is supplied, we want to adapt the `request`.
