### PR TITLE
Fix Signet::OAuth2::Client.new example arguments

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -77,9 +77,9 @@ module Signet
       #
       # @example
       #   client = Signet::OAuth2::Client.new(
-      #     :authorization_endpoint_uri =>
+      #     :authorization_uri =>
       #       'https://example.server.com/authorization',
-      #     :token_endpoint_uri =>
+      #     :token_credential_uri =>
       #       'https://example.server.com/token',
       #     :client_id => 'anonymous',
       #     :client_secret => 'anonymous',


### PR DESCRIPTION
The inline comment example has the wrong argument keys. This PR fixes them.