### PR TITLE
Fix warnings

### DIFF
--- a/lib/signet.rb
+++ b/lib/signet.rb
@@ -29,7 +29,6 @@ module Signet #:nodoc:
     # Combine the above production rules to find valid auth-param pairs.
     auth_param = /((?:#{token})\s*=\s*(?:#{d_qs}|#{s_qs}|#{token}))/
     auth_param_pairs = []
-    position = 0
     last_match = nil
     remainder = auth_param_string
     # Iterate over the string, consuming pair matches as we go.  Verify that

--- a/lib/signet/oauth_1/client.rb
+++ b/lib/signet/oauth_1/client.rb
@@ -979,7 +979,7 @@ module Signet
         content_type = content_type.split(';', 2).first if content_type.index(';')
         if request.method == :post && content_type == 'application/x-www-form-urlencoded'
           # Serializes the body in case a hash/array was passed. Noop if already string like
-          encoder = Faraday::Request::UrlEncoded.new(lambda { |env| })
+          encoder = Faraday::Request::UrlEncoded.new(lambda { |_env| })
           encoder.call(env)
           request.body = env[:body]
 

--- a/lib/signet/oauth_1/client.rb
+++ b/lib/signet/oauth_1/client.rb
@@ -592,7 +592,7 @@ module Signet
           :client_credential_secret => 'Client credential secret'
         }
         # Make sure all required state is set
-        verifications.each do |(key, value)|
+        verifications.each do |(key, _value)|
           unless self.send(key)
             raise ArgumentError, "#{key} was not set."
           end
@@ -748,7 +748,7 @@ module Signet
           :temporary_credential_secret => 'Temporary credential secret'
         }
         # Make sure all required state is set
-        verifications.each do |(key, value)|
+        verifications.each do |(key, _value)|
           unless self.send(key)
             raise ArgumentError, "#{key} was not set."
           end
@@ -912,7 +912,7 @@ module Signet
           )
         end
         # Make sure all required state is set
-        verifications.each do |(key, value)|
+        verifications.each do |(key, _value)|
           unless self.send(key)
             raise ArgumentError, "#{key} was not set."
           end

--- a/lib/signet/oauth_1/server.rb
+++ b/lib/signet/oauth_1/server.rb
@@ -250,7 +250,7 @@ module Signet
                                                          )
             }
         }
-        verifications.each do |(key, value)|
+        verifications.each do |(key, _value)|
           raise ArgumentError, "#{key} was not set." unless self.send(key)
         end
 
@@ -321,7 +321,7 @@ module Signet
           :verifier =>
             lambda {|x| 'Verifier' }
         }
-        verifications.each do |(key, value)|
+        verifications.each do |(key, _value)|
           unless self.send(key)
             raise ArgumentError, "#{key} was not set."
           end
@@ -405,7 +405,7 @@ module Signet
           )
         end
         # Make sure all required state is set
-        verifications.each do |(key, value)|
+        verifications.each do |(key, _value)|
           unless self.send(key)
             raise ArgumentError, "#{key} was not set."
           end

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -89,6 +89,22 @@ module Signet
       #
       # @see Signet::OAuth2::Client#update!
       def initialize(options={})
+        @authorization_uri    = nil
+        @client_id            = nil
+        @client_secret        = nil
+        @code                 = nil
+        @expires_at           = nil
+        @expires_in           = nil
+        @issued_at            = nil
+        @issued_at            = nil
+        @issuer               = nil
+        @password             = nil
+        @principal            = nil
+        @redirect_uri         = nil
+        @scope                = nil
+        @state                = nil
+        @token_credential_uri = nil
+        @username             = nil
         self.update!(options)
       end
 

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -297,7 +297,7 @@ module Signet
         @token_credential_uri = coerce_uri(new_token_credential_uri)
       end
 
-      # Addressable expects URIs formatted as hashes to come in with symbols as keys. 
+      # Addressable expects URIs formatted as hashes to come in with symbols as keys.
       # Returns nil implicitly for the nil case.
       def coerce_uri(incoming_uri)
         if incoming_uri.is_a? Hash
@@ -691,7 +691,7 @@ module Signet
       #
       # @return [String] The decoded ID token.
       def decoded_id_token(public_key=nil)
-        payload, header = JWT.decode(self.id_token, public_key, !!public_key)
+        payload, _header = JWT.decode(self.id_token, public_key, !!public_key)
         if !payload.has_key?('aud')
           raise Signet::UnsafeOperationError, 'No ID token audience declared.'
         elsif payload['aud'] != self.client_id
@@ -1130,7 +1130,7 @@ module Signet
       def uri_is_oob?(uri)
         return uri.to_s == 'urn:ietf:wg:oauth:2.0:oob' || uri.to_s == 'oob'
       end
-      
+
       # Convert all keys in this hash (nested) to symbols for uniform retrieval
       def recursive_hash_normalize_keys(val)
         if val.is_a? Hash

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -1157,10 +1157,10 @@ module Signet
       end
 
       def deep_hash_normalize(old_hash)
-        old_hash.inject(formatted_hash={}) do |formatted_hash,(k,v)|
+        old_hash.inject(formatted_hash={}) do |hash,(k,v)|
 
-          formatted_hash[k.to_sym] = recursive_hash_normalize_keys(v)
-          formatted_hash
+          hash[k.to_sym] = recursive_hash_normalize_keys(v)
+          hash
         end
 
         formatted_hash


### PR DESCRIPTION
This PR addresses several warnings that occur in the library. These warnings occur in projects that use signet. The warnings addressed are:

* assigned but unused variable
* instance variable not initialized
* shadowing outer local variable

You can see these warnings by enabling the -w flag when running the specs.

`$ RUBYOPT=-w rake spec`

(There are several more warnings in the specs that are not addressed in this PR, as they will not show up when simply using the library.)