### PR TITLE
Fixes OAuth2 authorization_uri assignement error.

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -259,6 +259,9 @@ module Signet
         options[:state] = self.state unless options[:state]
         options.merge!(self.additional_parameters.merge(options[:additional_parameters] || {}))
         options.delete(:additional_parameters)
+        options = Hash[options.map do |key, option|
+          [key.to_s, option]
+        end]
         uri = Addressable::URI.parse(
           ::Signet::OAuth2.generate_authorization_uri(
             @authorization_uri, options


### PR DESCRIPTION
Fixing issue where options' keys are required to be passed as symbols, but which eventually causes an error when attempting to compare with string keys for URI query values.

For demonstration/reproduction of the error in the current signet version, see this gist:
https://gist.github.com/swifthand/7c35c2c56619db5abbfd