### PR TITLE
The extlib gem is never used, so remove it from the gemspec.

### DIFF
--- a/signet.gemspec
+++ b/signet.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday', '~> 0.9'
   s.add_runtime_dependency 'multi_json', '~> 1.10'
   s.add_runtime_dependency 'jwt', '~> 1.5'
-  s.add_runtime_dependency 'extlib', '~> 0.9'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'


### PR DESCRIPTION
The tests pass in ruby 1.9, 2.1, and 2.2.