### PR TITLE
setup default options for authorization_uri

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -246,9 +246,9 @@ module Signet
       # @return [Addressable::URI] The authorization URI.
       #
       # @see Signet::OAuth2.generate_authorization_uri
-      def authorization_uri(options={})
+      def authorization_uri(options = {})
         # Normalize external input
-        options = deep_hash_normalize(options)
+        options = deep_hash_normalize(options || {})
 
         return nil if @authorization_uri == nil
         unless options[:response_type]


### PR DESCRIPTION
In some cases, for example in my case - google api client, [here](https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/auth/installed_app.rb#L110) we call authorization_uri method with nil argument, which causes error(signet/lib/signet/oauth_2/client.rb:1162:in `deep_hash_normalize'), so fix it.