### PR TITLE
Support for unix timestamps normalization on 32-bit system

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -1177,7 +1177,7 @@ module Signet
           time
         when String
           Time.parse(time)
-        when Fixnum
+        when Fixnum, Bignum
           Time.at(time)
         else
           fail "Invalid time value #{time}"


### PR DESCRIPTION
This patch fixes timestamp normalization on 32-bit systems where it fails with the following error:
`gems/signet-0.7.2/lib/signet/oauth_2/client.rb:1183:in 'normalize_timestamp': Invalid time value 1453993753 (RuntimeError)`
 
Quick analysis confirms that the issue is caused by the fact that unix timestamp on a 32-bit system is a `Bignum` while `normalize_timestamp` handles only `Fixnum`. Here is a little bit of irb o confirm the conjecture:
```
### Timestamp is a Bignum
2.3.0 :001 > Time.now.to_i
 => 1453995813 
2.3.0 :002 > Time.now.to_i.class
 => Bignum 
### Max Fixnum is rather small and cant handle unix time
2.3.0 :003 > MAXFIXNUM=(2**(0.size*8 -2) -1)
 => 1073741823 
```
 
The modification is really simple and basically adds parsing of the Bignum timestamps in addition to Fixnums which are already supported. It's also worth mentioning that current master fails two of the rake tests as they use Time.now to initialize the expires_at field and trigger the issue. The new version is working just fine:
- [Rake for master](https://gist.github.com/MikhailSamolinov/d5adc212d6a43b0fb57d)
- [Rake for PR 71](https://gist.github.com/MikhailSamolinov/a784cf8e39e0a6dcfc6f)