### PR TITLE
Add Bignum for normalize_timestamp

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -1177,7 +1177,7 @@ module Signet
           time
         when String
           Time.parse(time)
-        when Fixnum
+        when Fixnum, Bignum 
           Time.at(time)
         else
           fail "Invalid time value #{time}"


### PR DESCRIPTION
e.g Time stamp for 2016-03-16 18:47:45 -0400 is 1458168465 which is Bignum in ruby 2.1.7p400 (2015-08-18 revision 51632) [x64-mingw32]