### PR TITLE
The "expires_at" attribute should also be recalculated on refresh

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -738,8 +738,9 @@ module Signet
           @expires_in = new_expires_in.to_i
           @issued_at = Time.now
         else
-          @expires_in, @issued_at, @expires_at = nil, nil, nil
+          @expires_in, @issued_at = nil, nil
         end
+        @expires_at = nil
       end
 
       ##


### PR DESCRIPTION
By nil-ing the expires_at attribute, next time expires_at is accessed
through the reader, it will get recalculated.

As it is currently, when refreshing the access_token, the issued_at,
expires_in would get updated, but expires_at may still indicate that the
token has expired.
