### PR TITLE
Attribute "expires_at" is not getting updated after access token is refreshed

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -227,12 +227,19 @@ module Signet
 
         self.expires_in = options[:expires] if options.has_key?(:expires)
         self.expires_in = options[:expires_in] if options.has_key?(:expires_in)
-        self.expires_at = options[:expires_at] if options.has_key?(:expires_at)
 
         # By default, the token is issued at `Time.now` when `expires_in` is
         # set, but this can be used to supply a more precise time.
         self.issued_at = options[:issued_at] if options.has_key?(:issued_at)
 
+        # Once the token is refreshed, the expires_at should be updated by
+        # doing issued_at + expires_in
+        if options.has_key?(:expires_at)
+          self.expires_at = options[:expires_at] 
+        else 
+          self.expires_at = self.issued_at + self.expires_in if options.has_key?(:issued_at) && options.has_key?(:expires_in)
+        end
+        
         self.access_token = options[:access_token] if options.has_key?(:access_token)
         self.refresh_token = options[:refresh_token] if options.has_key?(:refresh_token)
         self.id_token = options[:id_token] if options.has_key?(:id_token)


### PR DESCRIPTION
Currently, when an access token is refreshed, the "expires_at" attribute holds the value that it is set when the constructor gets called. In case the "expires_at" is not provided to the constructor, nil value is returned after refreshing the token while "issued_at" and "expires_in" attributes are being updated. My understanding is that, once the token is refreshed, "expires_at" should not be the old date.

auth.expired? #=> returns true
auth.refresh! # updates the tokens successfully
auth.expired? #=> returns still true, even thought the token just got refreshed

I believe that that the correct behaviour should be that, if "expires_at" is not provided on the constructor, it should get calculted by adding "expires_in" to "issued_at". By doing this, the people could rely that once the token is refreshed the "expires_at" date will be set correctly.