### PR TITLE
Add the configured scope to the access token request.

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -940,7 +940,11 @@ module Signet
         end
         parameters['client_id'] = self.client_id unless self.client_id.nil?
         parameters['client_secret'] = self.client_secret unless self.client_secret.nil?
-        parameters['scope'] = options[:scope] if options[:scope]
+        if options[:scope]
+          parameters['scope'] = options[:scope]
+        elsif !self.scope.nil?
+          parameters['scope'] = self.scope
+        end
         additional = self.additional_parameters.merge(options[:additional_parameters] || {})
         additional.each { |k, v| parameters[k.to_s] = v }
         parameters

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -367,6 +367,13 @@ describe Signet::OAuth2::Client, 'configured for Google userinfo API' do
     expect(request).to include('assertion' => 'PEFzc2VydGlvbiBJc3N1ZUluc3RhbnQ9IjIwMTEtMDU')
   end
 
+  it 'should include the scope in token request' do
+    @client.scope = ['https://www.googleapis.com/auth/userinfo.profile']
+
+    request = @client.generate_access_token_request
+    expect(request).to include('scope' => ['https://www.googleapis.com/auth/userinfo.profile'])
+  end
+
   it 'should allow the token to be updated' do
     issued_at = Time.now
     @client.update_token!(


### PR DESCRIPTION
:scope as a value in options passed to generate_access_token_request is not even documented. But at the same time it discards if the object has been set up correctly with a scope. The Google Cloud fluentd plugin calls @client.authorization.fetch_access_token! (which inherits from Signet::OAuth2::Client) but the scope is then not copied over into the access token request, causing requests to Cloud Logging to fail. With this patch I was able to pass in a refresh token properly through the client's environment.