### PR TITLE
Support ruby-jwt 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.2.5
   - 2.1
   - 2.0.0
-  - jruby-9000
+  - jruby-9.1.9.0
 script: "rake spec:all"
 before_install:
  - sudo apt-get update

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -709,6 +709,7 @@ module Signet
       #
       # @return [String] The decoded ID token.
       def decoded_id_token(public_key=nil, options = {})
+        options[:algorithm] ||= signing_algorithm
         payload, _header = JWT.decode(self.id_token, public_key, !!public_key, options)
         if !payload.has_key?('aud')
           raise Signet::UnsafeOperationError, 'No ID token audience declared.'

--- a/signet.gemspec
+++ b/signet.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'addressable', '~> 2.3'
   s.add_runtime_dependency 'faraday', '~> 0.9'
   s.add_runtime_dependency 'multi_json', '~> 1.10'
-  s.add_runtime_dependency 'jwt', '~> 1.5'
+  s.add_runtime_dependency 'jwt', '>= 1.5', '< 3.0'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -199,7 +199,7 @@ describe Signet::OAuth2::Client, 'configured for assertions profile' do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode(jwt, @key.public_key, true)
+      claim, header = JWT.decode(jwt, @key.public_key, true, algorithm: 'RS256')
       expect(claim["iss"]).to eq 'app@example.com'
       expect(claim["scope"]).to eq 'https://www.googleapis.com/auth/userinfo.profile'
       expect(claim["aud"]).to eq 'https://accounts.google.com/o/oauth2/token'
@@ -210,7 +210,7 @@ describe Signet::OAuth2::Client, 'configured for assertions profile' do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode(jwt, @key.public_key, true)
+      claim, header = JWT.decode(jwt, @key.public_key, true, algorithm: 'RS256')
       expect(claim["iss"]).to eq 'app@example.com'
       expect(claim["prn"]).to eq 'user@example.com'
       expect(claim["scope"]).to eq 'https://www.googleapis.com/auth/userinfo.profile'
@@ -222,7 +222,7 @@ describe Signet::OAuth2::Client, 'configured for assertions profile' do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode(jwt, @key.public_key, true)
+      claim, header = JWT.decode(jwt, @key.public_key, true, algorithm: 'RS256')
       expect(claim["iss"]).to eq 'app@example.com'
       expect(claim["prn"]).to eq 'user@example.com'
       expect(claim["scope"]).to eq 'https://www.googleapis.com/auth/userinfo.profile'
@@ -234,7 +234,7 @@ describe Signet::OAuth2::Client, 'configured for assertions profile' do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode(jwt, @key.public_key, true)
+      claim, header = JWT.decode(jwt, @key.public_key, true, algorithm: 'RS256')
       expect(claim["iss"]).to eq 'app@example.com'
       expect(claim["sub"]).to eq 'user@example.com'
       expect(claim["scope"]).to eq 'https://www.googleapis.com/auth/userinfo.profile'
@@ -258,7 +258,7 @@ describe Signet::OAuth2::Client, 'configured for assertions profile' do
       stubs = Faraday::Adapter::Test::Stubs.new do |stub|
         stub.post('/o/oauth2/token') do |env|
           params = Addressable::URI.form_unencode(env[:body])
-          claim, header = JWT.decode(params.assoc("assertion").last, @key.public_key)
+          claim, header = JWT.decode(params.assoc("assertion").last, @key.public_key, true, algorithm: 'RS256')
           expect(params.assoc("grant_type")).to eq ['grant_type','urn:ietf:params:oauth:grant-type:jwt-bearer']
           build_json_response({
             "access_token" => "1/abcdef1234567890",
@@ -294,7 +294,7 @@ describe Signet::OAuth2::Client, 'configured for assertions profile' do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode(jwt, @key, true)
+      claim, header = JWT.decode(jwt, @key, true, algorithm: 'HS256')
       expect(claim["iss"]).to eq 'app@example.com'
       expect(claim["scope"]).to eq 'https://www.googleapis.com/auth/userinfo.profile'
       expect(claim["aud"]).to eq 'https://accounts.google.com/o/oauth2/token'


### PR DESCRIPTION
This version of ruby-jwt requires specification of the algorithm (see
https://github.com/jwt/ruby-jwt/pull/184) for more information.