### PR TITLE
Support Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.8
   - 2.1
   - 2.0.0
+  - 1.9.3
   - jruby-9.1.9.0
 script: "rake spec:all"
 before_install:

--- a/signet.gemspec
+++ b/signet.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/google/signet/"
   s.rdoc_options = ["--main", "README.md"]
   s.summary = "Signet is an OAuth 1.0 / OAuth 2.0 implementation."
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 1.9.3"
 
   s.add_runtime_dependency 'addressable', '~> 2.3'
   s.add_runtime_dependency 'faraday', '~> 0.9'


### PR DESCRIPTION
Googleauth, which depends on this library, currently still (attempts to) support Ruby 1.9.