### PR TITLE
Handle 5xx errors with RemoteServerError

### DIFF
--- a/lib/signet/errors.rb
+++ b/lib/signet/errors.rb
@@ -34,6 +34,12 @@ module Signet
   end
 
   ##
+  # An error indicating that the server failed at processing the request
+  # due to a internal error
+  class RemoteServerError < StandardError
+  end
+
+  ##
   # An error indicating the remote server refused to authorize the client.
   class AuthorizationError < StandardError
     ##

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -988,6 +988,12 @@ module Signet
           raise ::Signet::AuthorizationError.new(
             message, :response => response
           )
+        elsif status.to_s[0] == "5"
+          message = 'Remote server error.'
+          if body.to_s.strip.length > 0
+            message += "  Server message:\n#{response.body.to_s.strip}"
+          end
+          raise ::Signet::RemoteServerError.new(message)
         else
           message = "Unexpected status code: #{response.status}."
           if body.to_s.strip.length > 0


### PR DESCRIPTION
Currently 5xx errors return a Signet::AuthorizationError which is misleading

I added a Signet::RemoteServerError so they can be distinguished