### PR TITLE
Fix "Missing token endpoint URI" Error

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -804,7 +804,7 @@ module Signet
       # @return [TrueClass, FalseClass]
       #   The expiration state of the access token.
       def expires_within?(sec)
-        return self.expires_at.nil? || Time.now >= (self.expires_at - sec)
+        return self.expires_at != nil && Time.now >= (self.expires_at - sec)
       end
 
       ##

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -442,9 +442,9 @@ describe Signet::OAuth2::Client, 'configured for Google userinfo API' do
     expect(@client).to_not be_expired
   end
 
-  it 'should indicate the token is expired if expired_at nil' do
+  it 'should indicate the token is not expired if expired_at nil' do
     @client.expires_at = nil
-    expect(@client.expires_within?(60)).to be true
+    expect(@client.expires_within?(60)).to be false
   end
 
   it 'should indicate the token is not expiring when expiry beyond window' do


### PR DESCRIPTION
Fix #75

[oauth2client](https://github.com/google/oauth2client) which is the Python library for OAuth 2.0 by Google returns `False` in this case.

https://github.com/google/oauth2client/blob/v4.1.2/oauth2client/client.py#L635-L645

In the same way,  I think that `.expires_within?` of `Signet::OAuth2::Client` should return `false` when `expires_at` is `nil`. Also, in order to avoid this problem, it is a wrong solution to set `.expires_in` to value which is different from the actual one.