### PR TITLE
Calculate expires_at from issued_at, if provided

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -224,13 +224,13 @@ module Signet
         # Normalize all keys to symbols to allow indifferent access internally
         options = deep_hash_normalize(options)
 
-        self.expires_in = options[:expires] if options.has_key?(:expires)
-        self.expires_in = options[:expires_in] if options.has_key?(:expires_in)
-        self.expires_at = options[:expires_at] if options.has_key?(:expires_at)
-
         # By default, the token is issued at `Time.now` when `expires_in` is
         # set, but this can be used to supply a more precise time.
         self.issued_at = options[:issued_at] if options.has_key?(:issued_at)
+
+        self.expires_in = options[:expires] if options.has_key?(:expires)
+        self.expires_in = options[:expires_in] if options.has_key?(:expires_in)
+        self.expires_at = options[:expires_at] if options.has_key?(:expires_at)
 
         self.access_token = options[:access_token] if options.has_key?(:access_token)
         self.refresh_token = options[:refresh_token] if options.has_key?(:refresh_token)
@@ -742,7 +742,7 @@ module Signet
       #   The access token lifetime.
       def expires_in=(new_expires_in)
         if new_expires_in != nil
-          @issued_at = Time.now
+          @issued_at ||= Time.now
           @expires_at = @issued_at + new_expires_in.to_i
         else
           @expires_at, @issued_at = nil, nil
@@ -768,7 +768,7 @@ module Signet
 
       ##
       # Returns the timestamp the access token will expire at.
-      # Returns nil if the token does not expire. 
+      # Returns nil if the token does not expire.
       #
       # @return [Time, nil] The access token lifetime.
       def expires_at

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -435,6 +435,25 @@ describe Signet::OAuth2::Client, 'configured for Google userinfo API' do
     expect(@client).to be_expired
   end
 
+  it 'should calculate the expires_at from issued_at when issued_at is set' do
+    expires_in = 3600
+    issued_at = Time.now - expires_in
+    @client.update_token!(
+      :issued_at => issued_at,
+      :expires_in => expires_in
+    )
+    expect(@client.expires_at).to eq issued_at + expires_in
+    expect(@client).to be_expired
+  end
+
+  it 'should calculate expires_at from Time.now when issed_at is NOT set' do
+    expires_in = 3600
+    expires_at = Time.now + expires_in
+    @client.update_token! :expires_in => expires_in
+    expect(@client.expires_at).to be_within(1).of(expires_at)
+    expect(@client).to_not be_expired
+  end
+
   it 'should allow setting expires_at manually' do
     expires_at = Time.now+100
     @client.expires_at = expires_at.to_i


### PR DESCRIPTION
This pull request fixes a subtle issue where if a user provides `expires_in` and `issued_at`, the `expires_at` is calculated with `Time.now`, causing the client to never be expired.

Examples:
Current result
```ruby
# Assuming the current time is 2018-08-24T12:00:00
client.update_token!(
  expires_in: 3600,
  issued_at: '2018-08-24T00:00:00Z'
)
client.expires_at # => 2018-08-24T13:00:00
client.expired? # => false
```

Expected result
```ruby
# Assuming the current time is 2018-08-24T12:00:00
client.update_token!(
  expires_in: 3600,
  issued_at: '2018-08-24T00:00:00Z'
)
client.expires_at # => 2018-08-24T01:00:00
client.expired? # => true
```

Notice that `self.issued_at =` is moved above the expires code block, as `expires_in=` checks if `self.issued_at` is set or not.